### PR TITLE
Adding support for .NET 5

### DIFF
--- a/samples/GraphShape.Sample/GraphShape.Sample.csproj
+++ b/samples/GraphShape.Sample/GraphShape.Sample.csproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net472</TargetFrameworks>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <TargetFrameworks>net472;net5.0-windows10.0.17763.0</TargetFrameworks>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
 
     <Title>GraphShape.Sample</Title>
     <RootNamespace>GraphShape.Sample</RootNamespace>
@@ -13,7 +13,7 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2019</Copyright>
+    <Copyright>Copyright © 2021</Copyright>
     <Description>GraphShape sample application.</Description>
 
     <ApplicationIcon>..\..\docs\images\graphshape.ico</ApplicationIcon>
@@ -25,6 +25,9 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
     <AssemblyTitle>GraphShape.Sample .NET 4.7.2</AssemblyTitle>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.17763.0'">
+    <AssemblyTitle>GraphShape.Sample .NET 5</AssemblyTitle>
+  </PropertyGroup>
 
   <ItemGroup>
     <SplashScreen Include="..\..\docs\images\graphshape_logo.png" />
@@ -33,7 +36,8 @@
   <!-- Dependencies -->
   <!-- System -->
   <ItemGroup>
-    <Reference Include="System.Windows.Forms" />
+    <Reference Condition="'$(TargetFramework)'!='net5.0-windows10.0.17763.0'" Include="System.Windows.Forms" />
+    <FrameworkReference Condition="'$(TargetFramework)'=='net5.0-windows10.0.17763.0'" Include="Microsoft.WindowsDesktop.App" />
   </ItemGroup>
 
   <!-- Externals -->

--- a/samples/GraphShape.Sample/GraphShape.Sample.csproj
+++ b/samples/GraphShape.Sample/GraphShape.Sample.csproj
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net5.0-windows10.0.17763.0</TargetFrameworks>
-    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <TargetFrameworks>net5.0-windows</TargetFrameworks>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 
     <Title>GraphShape.Sample</Title>
     <RootNamespace>GraphShape.Sample</RootNamespace>
@@ -13,19 +13,17 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2021</Copyright>
+    <Copyright>Copyright © 2019</Copyright>
     <Description>GraphShape sample application.</Description>
 
     <ApplicationIcon>..\..\docs\images\graphshape.ico</ApplicationIcon>
     <OutputType>WinExe</OutputType>
+    <UseWindowsForms>true</UseWindowsForms>
     <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <!-- Targets defines -->
-  <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
-    <AssemblyTitle>GraphShape.Sample .NET 4.7.2</AssemblyTitle>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows10.0.17763.0'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
     <AssemblyTitle>GraphShape.Sample .NET 5</AssemblyTitle>
   </PropertyGroup>
 
@@ -34,15 +32,9 @@
   </ItemGroup>
 
   <!-- Dependencies -->
-  <!-- System -->
-  <ItemGroup>
-    <Reference Condition="'$(TargetFramework)'!='net5.0-windows10.0.17763.0'" Include="System.Windows.Forms" />
-    <FrameworkReference Condition="'$(TargetFramework)'=='net5.0-windows10.0.17763.0'" Include="Microsoft.WindowsDesktop.App" />
-  </ItemGroup>
-
   <!-- Externals -->
   <ItemGroup>
-    <PackageReference Include="QuikGraph.Serialization" Version="2.2.1" />
+    <PackageReference Include="QuikGraph.Serialization" Version="2.3.0" />
     <Reference Include="RibbonControlsLibrary, Version=3.5.31016.1, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Libraries\RibbonControlsLibrary.dll</HintPath>

--- a/samples/GraphShape.Sample/app.config
+++ b/samples/GraphShape.Sample/app.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-	<configSections>
+  <configSections>
     <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" >
       <section
         name="PoC.Properties.Settings"
@@ -29,7 +29,4 @@
       </setting>
     </GraphShape.Sample.Settings>
   </userSettings>
-  <startup> 
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
-  </startup>
 </configuration>

--- a/src/GraphShape.Controls/GraphShape.Controls.csproj
+++ b/src/GraphShape.Controls/GraphShape.Controls.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <UseWpf>true</UseWpf>
 
     <GeneratePackageOnBuild>$(Generate_GraphShape_Controls)</GeneratePackageOnBuild>
@@ -15,7 +15,7 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2019</Copyright>
+    <Copyright>Copyright © 2021</Copyright>
     <Description>GraphShape is a .NET graph layout framework based on Graph#.
 It contains several layout algorithms that allow various kind of layouts (FR, KK, ISOM, LinLog, Simple Tree, Circular, Sugiyama, Compound FDP, Random).
 
@@ -25,6 +25,8 @@ This library contains customizable controls for the visualization of graph in WP
 
 Supported platforms:
 - .NET Framework 3.5+
+- .NET Core 3.1+
+- .NET 5+
 
 Supports Source Link</Description>
 
@@ -48,6 +50,14 @@ New:
   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
     <AssemblyTitle>GraphShape.Controls .NET 4.5</AssemblyTitle>
     <DefineConstants>$(DefineConstants);NET45;$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <AssemblyTitle>GraphShape.Controls .NET Core 3.1</AssemblyTitle>
+    <DefineConstants>$(DefineConstants);NETCOREAPP31;$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
+    <AssemblyTitle>GraphShape.Controls .NET 5</AssemblyTitle>
+    <DefineConstants>$(DefineConstants);NET50;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Dependencies -->

--- a/src/GraphShape.Controls/GraphShape.Controls.csproj
+++ b/src/GraphShape.Controls/GraphShape.Controls.csproj
@@ -15,7 +15,7 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2021</Copyright>
+    <Copyright>Copyright © 2019</Copyright>
     <Description>GraphShape is a .NET graph layout framework based on Graph#.
 It contains several layout algorithms that allow various kind of layouts (FR, KK, ISOM, LinLog, Simple Tree, Circular, Sugiyama, Compound FDP, Random).
 
@@ -53,11 +53,11 @@ New:
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <AssemblyTitle>GraphShape.Controls .NET Core 3.1</AssemblyTitle>
-    <DefineConstants>$(DefineConstants);NETCOREAPP31;$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP3_1;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
     <AssemblyTitle>GraphShape.Controls .NET 5</AssemblyTitle>
-    <DefineConstants>$(DefineConstants);NET50;$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET5_0;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Dependencies -->

--- a/src/GraphShape/GraphShape.csproj
+++ b/src/GraphShape/GraphShape.csproj
@@ -14,7 +14,7 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2021</Copyright>
+    <Copyright>Copyright © 2019</Copyright>
     <Description>GraphShape is a .NET graph layout framework based on Graph#.
 It contains several layout algorithms that allow various kind of layouts (FR, KK, ISOM, LinLog, Simple Tree, Circular, Sugiyama, Compound FDP, Random).
 
@@ -58,7 +58,7 @@ New:
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
     <AssemblyTitle>GraphShape .NET 5</AssemblyTitle>
-    <DefineConstants>$(DefineConstants);NET50;SUPPORTS_ENUMERABLE_COVARIANT;SUPPORTS_CALLER_NAME;SUPPORTS_AGGRESSIVE_INLINING;$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET5_0;SUPPORTS_ENUMERABLE_COVARIANT;SUPPORTS_CALLER_NAME;SUPPORTS_AGGRESSIVE_INLINING;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
 
   <!-- Dependencies -->

--- a/src/GraphShape/GraphShape.csproj
+++ b/src/GraphShape/GraphShape.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;netstandard2.0;net5.0</TargetFrameworks>
 
     <GeneratePackageOnBuild>$(Generate_GraphShape_Core)</GeneratePackageOnBuild>
 
@@ -14,7 +14,7 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2019</Copyright>
+    <Copyright>Copyright © 2021</Copyright>
     <Description>GraphShape is a .NET graph layout framework based on Graph#.
 It contains several layout algorithms that allow various kind of layouts (FR, KK, ISOM, LinLog, Simple Tree, Circular, Sugiyama, Compound FDP, Random).
 
@@ -24,6 +24,7 @@ Supported platforms:
 - .NET Standard 2.0+
 - .NET Core 2.0+
 - .NET Framework 3.5+
+- .NET 5+
 
 Supports Source Link</Description>
 
@@ -55,9 +56,13 @@ New:
     <AssemblyTitle>GraphShape .NET Standard 2.0</AssemblyTitle>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_0;SUPPORTS_ENUMERABLE_COVARIANT;SUPPORTS_CALLER_NAME;SUPPORTS_AGGRESSIVE_INLINING;$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <AssemblyTitle>GraphShape .NET 5</AssemblyTitle>
+    <DefineConstants>$(DefineConstants);NET50;SUPPORTS_ENUMERABLE_COVARIANT;SUPPORTS_CALLER_NAME;SUPPORTS_AGGRESSIVE_INLINING;$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="QuikGraph" Version="2.2.0" />
+    <PackageReference Include="QuikGraph" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/src/GraphShape/Utils/GraphHelpers.cs
+++ b/src/GraphShape/Utils/GraphHelpers.cs
@@ -132,9 +132,7 @@ namespace GraphShape.Utils
                 int j = 0;
                 foreach (TVertex vertex in undirected.Vertices)
                 {
-#pragma warning disable CS0618 // Type or member is obsolete
-                    double distance = dijkstra.Distances[vertex];
-#pragma warning restore CS0618 // Type or member is obsolete
+                    double distance = dijkstra.GetDistance(vertex);
                     distances[i, j] = Math.Min(distances[i, j], distance);
                     distances[i, j] = Math.Min(distances[i, j], distances[j, i]);
                     distances[j, i] = Math.Min(distances[i, j], distances[j, i]);

--- a/src/GraphShape/Utils/GraphHelpers.cs
+++ b/src/GraphShape/Utils/GraphHelpers.cs
@@ -132,7 +132,9 @@ namespace GraphShape.Utils
                 int j = 0;
                 foreach (TVertex vertex in undirected.Vertices)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     double distance = dijkstra.Distances[vertex];
+#pragma warning restore CS0618 // Type or member is obsolete
                     distances[i, j] = Math.Min(distances[i, j], distance);
                     distances[i, j] = Math.Min(distances[i, j], distances[j, i]);
                     distances[j, i] = Math.Min(distances[i, j], distances[j, i]);

--- a/tests/GraphShape.Controls.Tests/GraphShape.Controls.Tests.csproj
+++ b/tests/GraphShape.Controls.Tests/GraphShape.Controls.Tests.csproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net5.0-windows</TargetFrameworks>
 
@@ -9,9 +9,8 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2021</Copyright>
+    <Copyright>Copyright © 2020</Copyright>
     <Description>Tests for GraphShape.Controls library.</Description>
-    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <!-- Targets defines -->
@@ -43,16 +42,14 @@
     <DefineConstants>$(DefineConstants);NET472;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
-    <DefineConstants>$(DefineConstants);NET50;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET5_0;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
+
   <!-- Dependencies -->
   <!-- System -->
   <ItemGroup Condition="'$(TargetFramework)'!='net5.0-windows'">
     <Reference Include="PresentationCore" />
     <Reference Include="WindowsBase" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
   </ItemGroup>
 
   <!-- GraphShape.Controls reference -->

--- a/tests/GraphShape.Controls.Tests/GraphShape.Controls.Tests.csproj
+++ b/tests/GraphShape.Controls.Tests/GraphShape.Controls.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;net5.0-windows</TargetFrameworks>
 
     <Title>GraphShape.Tests</Title>
 
@@ -9,8 +9,9 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2020</Copyright>
+    <Copyright>Copyright © 2021</Copyright>
     <Description>Tests for GraphShape.Controls library.</Description>
+    <UseWpf>true</UseWpf>
   </PropertyGroup>
 
   <!-- Targets defines -->
@@ -41,12 +42,17 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
     <DefineConstants>$(DefineConstants);NET472;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
+    <DefineConstants>$(DefineConstants);NET50;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
   <!-- Dependencies -->
   <!-- System -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='net5.0-windows'">
     <Reference Include="PresentationCore" />
     <Reference Include="WindowsBase" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
+    <FrameworkReference Include="Microsoft.WindowsDesktop.App" />
   </ItemGroup>
 
   <!-- GraphShape.Controls reference -->

--- a/tests/GraphShape.Tests/GraphShape.Tests.csproj
+++ b/tests/GraphShape.Tests/GraphShape.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
 
     <Title>GraphShape.Tests</Title>
 
@@ -9,7 +9,7 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2019</Copyright>
+    <Copyright>Copyright © 2021</Copyright>
     <Description>Tests for GraphShape library.</Description>
   </PropertyGroup>
 
@@ -41,18 +41,18 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='net472'">
     <DefineConstants>$(DefineConstants);NET472;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
-    <DefineConstants>$(DefineConstants);NETCOREAPP2_0;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <DefineConstants>$(DefineConstants);NETCOREAPP31;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
+    <DefineConstants>$(DefineConstants);NET50;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
   <!-- Dependencies -->
   <!-- System -->
-  <ItemGroup>
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp2.0'">
+  <ItemGroup Condition="!$(TargetFramework.StartsWith('netcore')) And '$(TargetFramework)'!='net5.0-windows10.0.17763.0'">
     <Reference Include="PresentationFramework" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
 
   <!-- Projects  -->

--- a/tests/GraphShape.Tests/GraphShape.Tests.csproj
+++ b/tests/GraphShape.Tests/GraphShape.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;netcoreapp3.1;net5.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>net35;net40;net45;net451;net452;net46;net461;net462;net47;net471;net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
 
     <Title>GraphShape.Tests</Title>
 
@@ -9,7 +9,7 @@
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
 
-    <Copyright>Copyright © 2021</Copyright>
+    <Copyright>Copyright © 2019</Copyright>
     <Description>Tests for GraphShape library.</Description>
   </PropertyGroup>
 
@@ -42,19 +42,13 @@
     <DefineConstants>$(DefineConstants);NET472;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);NETCOREAPP31;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP3_1;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0-windows'">
-    <DefineConstants>$(DefineConstants);NET50;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
+    <DefineConstants>$(DefineConstants);NET5_0;SUPPORTS_TASKS$(AdditionalConstants)</DefineConstants>
   </PropertyGroup>
+
   <!-- Dependencies -->
-  <!-- System -->
-
-  <ItemGroup Condition="!$(TargetFramework.StartsWith('netcore')) And '$(TargetFramework)'!='net5.0-windows10.0.17763.0'">
-    <Reference Include="PresentationFramework" />
-    <Reference Include="WindowsBase" />
-  </ItemGroup>
-
   <!-- Projects  -->
   <ItemGroup>
     <ProjectReference Include="..\..\common\GraphShape.Factory\GraphShape.Factory.csproj" />


### PR DESCRIPTION
Thanks for bringing this code to GitHub and keeping it up to date.

This pull requests adds (explicit) support for .NET5. I've tried to keep the changes as small as possible and the warnings at 0.

We are using this component and just updated from .NET 4.8 to .NET 5. When doing that we've been getting intermittent dead-locks when redrawing the graph. This merge request is a first attempt to resolve that. It could be completely unrelated, but upgrading this to .NET5 means one warning less and hopefully makes the package more visible to new projects.