### PR TITLE
Remove not required assignment in CalculateLayerSizesAndPositions

### DIFF
--- a/src/GraphShape/Algorithms/Layout/Simple/Hierarchical/SugiyamaLayoutAlgorithm.SliceAssignments.cs
+++ b/src/GraphShape/Algorithms/Layout/Simple/Hierarchical/SugiyamaLayoutAlgorithm.SliceAssignments.cs
@@ -307,7 +307,6 @@ namespace GraphShape.Algorithms.Layout
 
             double layerDistance = Parameters.LayerGap;
             _layerPositions = new double[_layers.Count];
-            _layerPositions[0] = 0;
             for (int i = 1; i < _layers.Count; ++i)
             {
                 _layerPositions[i] = _layerPositions[i - 1] + _layerSizes[i - 1] + layerDistance;


### PR DESCRIPTION
Remove assignment, because default initialize is already happening one line before.